### PR TITLE
Prevent occasional UI lockup

### DIFF
--- a/Workbench.xaml.cs
+++ b/Workbench.xaml.cs
@@ -431,8 +431,8 @@ namespace LogicLink.Corona {
                 pbr.Visibility = Visibility.Visible;
             else if(!e.Value.Show && pbr.Visibility != Visibility.Collapsed)
                 pbr.Visibility = Visibility.Collapsed;
-
-            pbr.Dispatcher.Invoke(delegate () { }, DispatcherPriority.Background);
+            
+            pbr.Dispatcher.Invoke(delegate () { }, DispatcherPriority.Render);
         }
 
         private void btnData_Click(object sender, RoutedEventArgs e) => new Data(cht.ToDataTable()).ShowDialog();


### PR DESCRIPTION
The purpose of this line appears to be to forcibly update the progress bar, but this often causes the UI to freeze if you attempt to move the main window during the data initialization at app startup.